### PR TITLE
Fix options in setOptions

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
@@ -30,15 +30,11 @@ class PlaylistPlugin : Plugin(), OnStatusReportListener {
     }
     @PluginMethod
     fun setOptions(call: PluginCall) {
-        val options: JSObject = call.getObject("options")
+        val options: JSObject = call.getObject("options") ?: JSObject()
         resetStreamOnPause = options.optBoolean("resetStreamOnPause", this.resetStreamOnPause)
-        var jsonOptions = options.optJSONObject("options")
-        if (jsonOptions == null) {
-            jsonOptions = JSONObject()
-        }
-        Log.i("AudioPlayerOptions", jsonOptions.toString())
+        Log.i("AudioPlayerOptions", options.toString())
         audioPlayerImpl!!.resetStreamOnPause = resetStreamOnPause
-        audioPlayerImpl!!.setOptions(jsonOptions)
+        audioPlayerImpl!!.setOptions(options)
         call.resolve()
     }
 


### PR DESCRIPTION
When adding a track to playlists, Android app was crashed. In my case, it's due small icon was not set.

```
java.lang.IllegalArgumentException: Invalid notification (no valid small icon): Notification(channel=PlaylistCoreMediaNotificationChannel pri=0 contentView=null vibrate=null sound=null defaults=0x0 flags=0x10 color=0x00000000 category=transport actions=3 vis=PUBLIC)
```


`setOptions` is not working currently.  Access `options` twice in `setOptions` so `options.icon` was not set. Fixed to access `options` correctly.

I think https://github.com/phiamo/capacitor-plugin-playlist/issues/13 is same problem.
