### PR TITLE
Add duration property on web

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -306,6 +306,7 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
             currentIndex: this.getCurrentIndex(),
             status: currentState,
             currentPosition: this.audio?.currentTime || 0,
+            duration: this.audio?.duration || 0,
         };
     }
 


### PR DESCRIPTION
Added duration property because it does not exist in the value from the status event on only web.