### PR TITLE
Add "prepare" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.js",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepare": "npm run build"
   },
   "author": "phiamo",
   "license": "MIT",


### PR DESCRIPTION
See: https://stackoverflow.com/a/57829251/15187023

Without this, new dist folder is not installed on npm install. 
So for instance, "Add duration property on web #22" was not part of the build after npm install, since it would only be build npm publish.

I am no expert in this matter, so I am not sure if "prepublishOnly" should be removed.