### PR TITLE
Change STOPPED to COMPLETED on web on audio end

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -265,7 +265,7 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
             });
 
             this.audio.addEventListener('ended', () => {
-                this.updateStatus(RmxAudioStatusMessage.RMXSTATUS_STOPPED, this.getCurrentTrackStatus('stopped'));
+                this.updateStatus(RmxAudioStatusMessage.RMXSTATUS_COMPLETED, this.getCurrentTrackStatus('stopped'));
             });
 
             let lastTrackId: any, lastPosition: any;


### PR DESCRIPTION
When audio has ended, emit COMPLETED instead of STOPPED for web, so it's consistent with Android and iOS. 