### PR TITLE
When clicking a disabled next button in media controls on android, th…

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
@@ -48,8 +48,9 @@ public class AudioPlaylistHandler<I extends PlaylistItem, M extends BasePlaylist
     }
 
     public void next() {
-        getPlaylistManager().next();
-        startItemPlayback(0, !this.isPlaying());
+        if (getPlaylistManager().next() != null) {
+            startItemPlayback(0, !this.isPlaying());
+        }
     }
 
     @Override


### PR DESCRIPTION
…e media should not restart.

Currently when clicking next in the media controls on a disabled next button, the audio restarts.
Changed this behavior so the next button doesn't do anything if there isn't anything left in the playlist queue, as I would think is expected behavior. 