### PR TITLE
Android emit completed consistently

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/RmxAudioPlayer.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/RmxAudioPlayer.java
@@ -100,6 +100,13 @@ public class RmxAudioPlayer implements PlaybackStatusListener<AudioTrack>,
         playlistManager.setVolume(left, right);
     }
 
+    public void onCompletion(AudioTrack item) {
+        if (item != null) {
+            String trackId = item.getTrackId();
+            JSONObject trackStatus = getPlayerStatus(item);
+            onStatus(RmxAudioStatusMessage.RMXSTATUS_COMPLETED, trackId, trackStatus);
+        }
+    }
 
     @Override
     public void onPrevious(AudioTrack currentItem, int currentIndex) {
@@ -180,7 +187,7 @@ public class RmxAudioPlayer implements PlaybackStatusListener<AudioTrack>,
         if (item != null) {
             String trackId = item.getTrackId();
             JSONObject trackStatus = getPlayerStatus(item);
-            onStatus(RmxAudioStatusMessage.RMXSTATUS_COMPLETED, trackId, trackStatus);
+            onStatus(RmxAudioStatusMessage.RMXSTATUS_STOPPED, trackId, trackStatus);
         }
 
         if (nextItem == null) { // if (!playlistManager.isNextAvailable()) {

--- a/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
@@ -17,6 +17,7 @@ import com.devbrackets.android.playlistcore.components.mediasession.DefaultMedia
 import com.devbrackets.android.playlistcore.components.mediasession.MediaSessionProvider;
 import com.devbrackets.android.playlistcore.components.playlisthandler.DefaultPlaylistHandler;
 import com.devbrackets.android.playlistcore.manager.BasePlaylistManager;
+import org.dwbn.plugins.playlist.RmxAudioPlayer;
 import org.dwbn.plugins.playlist.data.AudioTrack;
 import org.dwbn.plugins.playlist.manager.PlaylistManager;
 import org.dwbn.plugins.playlist.notification.PlaylistNotificationProvider;

--- a/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
@@ -90,6 +90,7 @@ public class AudioPlaylistHandler<I extends PlaylistItem, M extends BasePlaylist
 
     @Override
     public void onCompletion(@NotNull MediaPlayerApi<I> mediaPlayer) {
+        ((RmxAudioPlayer)super.getPlaylistManager().getPlaybackStatusListener()).onCompletion((AudioTrack) getCurrentPlaylistItem());
         Log.i("AudioPlaylistHandler", "onCompletion");
         // This is called when a single item completes playback.
         // For now, the superclass does the right thing, but we may need to override.


### PR DESCRIPTION
Right now Android emits COMPLETED event whenever an audio track is stopped, which is inconsistent to WEB and iOS. 
I have changed this so Android emits STOPPED when audio is stopped and COMPLETED _only_ when the track is actually completed (listened to the end). 