### PR TITLE
Android: Plugin not emitting any events after relaunching app while media is playing

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/App.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/App.kt
@@ -14,7 +14,12 @@ import okhttp3.OkHttpClient
 import java.io.File
 
 class App : Application() {
-    val playlistManager: PlaylistManager by lazy { PlaylistManager(this) }
+    private lateinit var _playlistManager: PlaylistManager;
+    val playlistManager get() = _playlistManager
+
+    fun resetPlaylistManager() {
+        _playlistManager = PlaylistManager(this)
+    }
 
     override fun onCreate() {
         super.onCreate()

--- a/android/src/main/java/org/dwbn/plugins/playlist/RmxAudioPlayer.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/RmxAudioPlayer.java
@@ -54,6 +54,7 @@ public class RmxAudioPlayer implements PlaybackStatusListener<AudioTrack>,
         this.statusListener = statusListener;
         this.app = context;
 
+        app.resetPlaylistManager();
         getPlaylistManager();
         playlistManager.setId(PLAYLIST_ID);
         playlistManager.setPlaybackStatusListener(this);


### PR DESCRIPTION
So this one was actually pretty critical as it basically rendered the player completely broken on Android. 

**Reproduce:**
Tested on Huawei P30 Pro
* Open the app on Android and start playing audio.
* _Without_ pausing the audio, now minimize the app and 'swipe it away' in 'running apps overview'
* This closes the app and stops the Audio from playing, but since the Audio was not paused, for some reason the App/Plugin is not completely killed.
* Reopen the app and start playing audio again; **90% of events that should be emitted will be missing**

This took some debugging as this behavior was really odd, but it turns out that even though we make a new instance `RmxAudioPlayer`, we use the _old_ `PlaylistManager`, which has references to the _old_ `RmxAudioPlayer` from our last session. 

This caused the `PlaylistManager` to have more registered listeners pointing to the old and the new `RmxAudioPlayer`. 
When a new event was registered the `PlaylistManager` iterated over the listeners and notified them, _but_, only the first listener in the list of listeners gets notified.
_Notice the `return` in the loop_
![image](https://user-images.githubusercontent.com/100521595/177550815-433fe49f-ac0a-49b7-ac87-7768fcb3f272.png)

The solution I went with, is to make sure we create a _new_ `PlaylistManager` ever time we create a new `RmxAudioPlayer` instance. 