### PR TITLE
suggestion to fix type error in example code

### DIFF
--- a/examples/audio-provider.ts
+++ b/examples/audio-provider.ts
@@ -5,7 +5,7 @@ import {
   AudioTrackRemoval,
   OnStatusCallbackData,
   OnStatusErrorCallbackData,
-  AudioTrackOptions,
+  PlaylistItemOptions,
   RmxAudioPlayer,
 } from 'capacitor-plugin-playlist';
 import 'capacitor-plugin-playlist';
@@ -65,7 +65,7 @@ export class AudioProvider {
   async setPlaylistItems(audioTracks: AudioTrack[], currentItem?: AudioTrack, currentPosition= 0) {
     let currentId = null;
 
-    let options: AudioTrackOptions = {};
+    let options: PlaylistItemOptions = {};
     if (currentItem) {
       currentId = currentItem.trackId;
       const startPaused = !this.isPlaying;


### PR DESCRIPTION
As described in Issue 20, while using this plugin's example code (examples/audio-provider.ts), I encountered a type error:

Error: error TS2345: Argument of type 'AudioTrackOptions' is not assignable to parameter of type 'PlaylistItemOptions'.
Types of property 'playFromId' are incompatible.
Type 'string' is not assignable to type 'number'.

I suspect the setPlaylistItems function in the example code should be this:

let options: PlaylistItemOptions = {};
instead of

let options: AudioTrackOptions = {};