### PR TITLE
Do nothing when pressing a disabled 'previous' button in media controls

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
@@ -49,9 +49,19 @@ public class AudioPlaylistHandler<I extends PlaylistItem, M extends BasePlaylist
     }
 
     public void next() {
-        if (getPlaylistManager().next() != null) {
-            startItemPlayback(0, !this.isPlaying());
+        if (!getPlaylistManager().isNextAvailable()) {
+            return;
         }
+        getPlaylistManager().next();
+        startItemPlayback(0, !this.isPlaying());
+    }
+
+    public void previous() {
+        if (!getPlaylistManager().isPreviousAvailable()) {
+            return;
+        }
+        getPlaylistManager().previous();
+        startItemPlayback(0, !this.isPlaying());
     }
 
     @Override


### PR DESCRIPTION
and use same pattern in next().
Currently when clicking the previous button when it's disabled the current track will start over. A disabled button shouldn't do anything. 