### PR TITLE
Update mediacontrols after adding/removing playlist items on Android

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
@@ -143,6 +143,7 @@ class PlaylistManager(application: Application) :
             currentPosition = 0
             beginPlayback(1, true)
         }
+        this.playlistHandler!!.updateMediaControls()
     }
 
     fun addAllItems(its: List<AudioTrack>?) {
@@ -151,6 +152,7 @@ class PlaylistManager(application: Application) :
         items =
             audioTracks // not *strictly* needed since they share the reference, but for good measure..
         currentPosition = audioTracks.indexOf(currentItem)
+        this.playlistHandler!!.updateMediaControls()
     }
 
     fun removeItem(index: Int, itemId: String): AudioTrack? {
@@ -177,6 +179,7 @@ class PlaylistManager(application: Application) :
         items = audioTracks
         currentPosition = if (removingCurrent) currentPosition else audioTracks.indexOf(currentItem)
         beginPlayback(currentPosition.toLong(), !wasPlaying)
+        this.playlistHandler!!.updateMediaControls()
         return foundItem
     }
 
@@ -203,6 +206,7 @@ class PlaylistManager(application: Application) :
         items = audioTracks
         currentPosition = if (removingCurrent) currentPosition else audioTracks.indexOf(currentItem)
         beginPlayback(currentPosition.toLong(), !wasPlaying)
+        this.playlistHandler!!.updateMediaControls()
         return removedTracks
     }
 

--- a/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
@@ -152,7 +152,6 @@ class PlaylistManager(application: Application) :
         items =
             audioTracks // not *strictly* needed since they share the reference, but for good measure..
         currentPosition = audioTracks.indexOf(currentItem)
-        this.playlistHandler!!.updateMediaControls()
     }
 
     fun removeItem(index: Int, itemId: String): AudioTrack? {
@@ -206,7 +205,6 @@ class PlaylistManager(application: Application) :
         items = audioTracks
         currentPosition = if (removingCurrent) currentPosition else audioTracks.indexOf(currentItem)
         beginPlayback(currentPosition.toLong(), !wasPlaying)
-        this.playlistHandler!!.updateMediaControls()
         return removedTracks
     }
 


### PR DESCRIPTION
Update mediacontrols so next/previous button is enabled/disabled after adding/removing items.

The bug I noticed:
* Create a playlist with 1 item so the next button is disabled
* Use function _RmxAudioPlayer.addItem()_ so there are 2 tracks in the playlist
* Next button stayed disabled instead of updating