### PR TITLE
Fix nullPointer exception on Android when calling addItem/removeItem after BasePlaylistService is destroyed

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
@@ -143,7 +143,9 @@ class PlaylistManager(application: Application) :
             currentPosition = 0
             beginPlayback(1, true)
         }
-        this.playlistHandler!!.updateMediaControls()
+        if (this.playlistHandler != null) {
+            this.playlistHandler!!.updateMediaControls()
+        }
     }
 
     fun addAllItems(its: List<AudioTrack>?) {
@@ -178,7 +180,9 @@ class PlaylistManager(application: Application) :
         items = audioTracks
         currentPosition = if (removingCurrent) currentPosition else audioTracks.indexOf(currentItem)
         beginPlayback(currentPosition.toLong(), !wasPlaying)
-        this.playlistHandler!!.updateMediaControls()
+        if (this.playlistHandler != null) {
+            this.playlistHandler!!.updateMediaControls()
+        }
         return foundItem
     }
 


### PR DESCRIPTION
this.playlistHandler!!.updateMediaControls() would crash if this.playlistHandler == null