### PR TITLE
options.playFromId should not be dependent on options.retainPosition

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
@@ -115,10 +115,8 @@ class PlaylistManager(application: Application) :
 
         // If the options said to start from a specific id, do so.
         var idStart: String? = null
-        if (options.retainPosition) {
-            if (options.playFromId != null) {
-                idStart = options.playFromId
-            }
+        if (options.playFromId != null) {
+            idStart = options.playFromId
         }
         if (idStart != null && "" != idStart) {
             val code = idStart.hashCode()


### PR DESCRIPTION
I don't see any reason why these should be dependent. Gave me problems when wanting to play from a specific trackId but did not want to retain position from previous track. 