### PR TITLE
When there is no track set for the playlist, it should emit TRACK_CHANGED for ANY track being started again afterwards

### DIFF
--- a/ios/Plugin/RmxAudioPlayer.swift
+++ b/ios/Plugin/RmxAudioPlayer.swift
@@ -542,12 +542,14 @@ final class RmxAudioPlayer: NSObject {
             let player = object as? AVBidirectionalQueuePlayer
             let playerItem = player?.currentAudioTrack
             if playerItem != nil {
-            guard !isReplacingItems && self.lastTrackId != playerItem?.trackId else {
-                return
-            }
-            print("observe change currentItem: lastTrackId \(self.lastTrackId) playerItem: \(playerItem?.trackId)")
-            self.lastTrackId = playerItem?.trackId
-            handleCurrentItemChanged(playerItem)
+                guard !isReplacingItems && self.lastTrackId != playerItem?.trackId else {
+                    return
+                }
+                print("observe change currentItem: lastTrackId \(self.lastTrackId) playerItem: \(playerItem?.trackId)")
+                self.lastTrackId = playerItem?.trackId
+                handleCurrentItemChanged(playerItem)
+            }  else {
+                self.lastTrackId = nil
             }
             
         case "rate":


### PR DESCRIPTION
Reproduce: 
* Start a playlist with 1 track 
* Finish the playlist so there is now no active track in the playlist
* Start the same track again and the TRACK_CHANGED event will not be emitted (even after clearing all items/setting all items again).

Same will probably happen with more tracks in the playlist, if you try to play the last track again, since the 'lastTrackId' variable is NEVER reset. 