### PR TITLE
When calling setPlaylistItems with playFromId set, it would not work because the look up would be in the previous track items, and not the new ones. 

### DIFF
--- a/ios/Plugin/RmxAudioPlayer.swift
+++ b/ios/Plugin/RmxAudioPlayer.swift
@@ -962,6 +962,26 @@ final class RmxAudioPlayer: NSObject {
         }
     }
 
+    func findTrackIndex(byId trackId: String?, _ tracks: [AudioTrack]) -> [String: Any]? {
+        let trackInformation: (Int, AudioTrack)? = tracks
+            .enumerated()
+            .first(where: { _, track in
+                track.trackId == trackId
+            })
+
+        guard
+            let index = trackInformation?.0,
+            let track = trackInformation?.1
+        else {
+            return nil
+        }
+
+        return [
+            "track": track,
+            "index": NSNumber(value: index)
+        ]
+    }
+
     func findTrack(byId trackId: String?) -> [String: Any]? {
         let trackInformation: (Int, AudioTrack)? = avQueuePlayer.queuedAudioTracks
             .enumerated()

--- a/ios/Plugin/RmxAudioPlayer.swift
+++ b/ios/Plugin/RmxAudioPlayer.swift
@@ -81,7 +81,8 @@ final class RmxAudioPlayer: NSObject {
             seekToPosition = getTrackCurrentTime(nil)
         }
 
-        let result = findTrack(byId: playFromId)
+        // Index needs to come from new tracks, so we find it in 'items'
+        let result = findTrackIndex(byId: playFromId, items)
         let idx = (result?["index"] as? NSNumber)?.intValue ?? 0
 
         setTracks(items, startIndex: idx, startPosition: seekToPosition)


### PR DESCRIPTION
It would not find the ID in the old list, and index 0 would be used as fallback. 

Also, it could potentially give an index out of bounds exception, if they id by chance was available in the previous track items, but at an index that is out of bounds in the new track items...