### PR TITLE
fix: 🐛 fix currentTime when changing track

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -68,6 +68,9 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
             if (track.trackId === options.id) {
                 if (track !== this.currentTrack) {
                     await this.setCurrent(track);
+                    if (options.position > 0) {
+                        this.audio.currentTime = options.position;
+                    }
                 }
                 return this.play();
             }
@@ -80,6 +83,9 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
             if (index === options.index) {
                 if (item !== this.currentTrack) {
                     await this.setCurrent(item);
+                    if (options.position > 0) {
+                        this.audio.currentTime = options.position;
+                    }
                 }
                 return this.play();
             }


### PR DESCRIPTION
The web player is not respecting the currentTime passed to those two methods.
I haven't tested that much on iOS and Android yet, but it seems to have the same issue.