### PR TITLE
Fix lint errors.

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -68,7 +68,7 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
             if (track.trackId === options.id) {
                 if (track !== this.currentTrack) {
                     await this.setCurrent(track);
-                    if (options.position > 0) {
+                    if (this.audio && options?.position && options.position > 0) {
                         this.audio.currentTime = options.position;
                     }
                 }
@@ -83,7 +83,7 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
             if (index === options.index) {
                 if (item !== this.currentTrack) {
                     await this.setCurrent(item);
-                    if (options.position > 0) {
+                    if (this.audio && options?.position && options.position > 0) {
                         this.audio.currentTime = options.position;
                     }
                 }


### PR DESCRIPTION
 Make sure we don't access undefined/null object.
![image](https://user-images.githubusercontent.com/100521595/211153142-ed294e16-538f-4539-8b14-5597fb627fbe.png)

This was caused by commit #61.