### PR TITLE
Set PendingIntent flag explicitly as required by Google for API31+ 

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/notification/PlaylistNotificationProvider.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/notification/PlaylistNotificationProvider.kt
@@ -3,6 +3,7 @@ package org.dwbn.plugins.playlist.notification
 import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
+import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.content.Context
 import android.content.Intent
 import com.devbrackets.android.playlistcore.components.notification.DefaultPlaylistNotificationProvider
@@ -19,7 +20,7 @@ class PlaylistNotificationProvider(context: Context?) : DefaultPlaylistNotificat
             intent!!.addFlags(
                     Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_SINGLE_TOP)
             return PendingIntent.getActivity(this.context,
-                    0, intent, FLAG_UPDATE_CURRENT
+                    0, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE
             )
         }
 }


### PR DESCRIPTION
How to reproduce: 
Startup app with the plugin on device running Android 12 API31 (or higher) and it will give the following error on startup and crash the app entirely:

_Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent_

I have also mentioned this in discussion for #25 