### PR TITLE
iOS auto loop back

### DIFF
--- a/ios/Plugin/RmxAudioPlayer.swift
+++ b/ios/Plugin/RmxAudioPlayer.swift
@@ -475,6 +475,12 @@ final class RmxAudioPlayer: NSObject {
         if (avQueuePlayer.isAtEnd) {
             onStatus(.rmxstatus_PLAYLIST_COMPLETED, trackId: "INVALID", param: nil)
         }
+        
+        if loop && avQueuePlayer.isAtEnd {
+            print("Last music in playlist play ended, loop back.")
+            avQueuePlayer.setCurrentIndex(0)
+            avQueuePlayer.play()
+        }
     }
 
     @objc func handleAudioSessionInterruption(_ interruptionNotification: Notification?) {


### PR DESCRIPTION
Currently iOS playlist which enabled loop mode, it can play back first music if we call `next()`, but unable to replay after the last music play ended.

This PR add this behavior that make player back to first if the last music play ended.