### PR TITLE
StartPaused default value wrong in Android

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/PlaylistItemOptions.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/PlaylistItemOptions.java
@@ -18,7 +18,7 @@ public class PlaylistItemOptions {
     }
 
     this.retainPosition = this.options.optBoolean("retainPosition", false);
-    this.startPaused = this.options.optBoolean("startPaused", true);
+    this.startPaused = this.options.optBoolean("startPaused", false);
     this.playFromId = this.options.optString("playFromId", null);
 
     try {


### PR DESCRIPTION
As this describe that default value of `startPaused` should be `FALSE`

https://github.com/phiamo/capacitor-plugin-playlist/blob/a689adc766437edfa91165360c0a9ac54452a85c/src/interfaces.ts#L81-L85

I changed startPaused fallback to `false` in Android.