### PR TITLE
Use MediaPlayer's MPNowPlayingInfoCenter to remove nowPlayingInfo

### DIFF
--- a/ios/Plugin/AVBidirectionalQueuePlayer.swift
+++ b/ios/Plugin/AVBidirectionalQueuePlayer.swift
@@ -26,6 +26,7 @@
 //
 
 import AVFoundation
+import MediaPlayer
 
 let AVBidirectionalQueueAddedItem = "AVBidirectionalQueuePlayer.AddedItem"
 let AVBidirectionalQueueAddedAllItems = "AVBidirectionalQueuePlayer.AddedAllItems"
@@ -199,6 +200,8 @@ class AVBidirectionalQueuePlayer: AVQueuePlayer {
         super.removeAllItems()
         queuedAudioTracks.removeAll()
 
+        MPNowPlayingInfoCenter.default().nowPlayingInfo?.removeAll()
+
         NotificationCenter.default.post(name: NSNotification.Name(AVBidirectionalQueueCleared), object: self, userInfo: nil)
     }
 
@@ -207,7 +210,7 @@ class AVBidirectionalQueuePlayer: AVQueuePlayer {
             removeTrackObservers(item)
         }
     }
-    
+
     func removeTrackObservers(_ playerItem: AudioTrack?) {
         NotificationCenter.default.removeObserver(self, name: .AVPlayerItemDidPlayToEndTime, object: playerItem)
         NotificationCenter.default.removeObserver(self, name: .AVPlayerItemPlaybackStalled, object: playerItem)


### PR DESCRIPTION
The notification center keeps the last played track even after clearing the playlist (see Issue #67). Adding the call to MPNowPlayingInfoCenter in removeAllItems fixes this issue for me.

Tested on iOS 15.6.1