### PR TITLE
update the web audio init, release and options. Resolves stalling audio playback when transcoding

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -22,7 +22,7 @@ import { validateTrack, validateTracks } from './utils';
 declare var Hls: any;
 
 export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
-    protected audio: HTMLVideoElement | undefined;
+    protected audio: HTMLAudioElement | undefined;
     protected playlistItems: AudioTrack[] = [];
     protected loop = false;
     protected options: AudioPlayerOptions = {};
@@ -51,6 +51,11 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
     }
 
     async initialize(): Promise<void> {
+        this.audio = new Audio();
+        this.audio.crossOrigin = 'anonymous';
+        this.audio.preload = 'auto';
+        this.audio.controls = true;
+        this.audio.autoplay = false;
         this.updateStatus(RmxAudioStatusMessage.RMXSTATUS_INIT, null, "INVALID");
         return Promise.resolve();
     }
@@ -96,6 +101,7 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
     async release(): Promise<void> {
         await this.pause();
         this.audio = undefined;
+        await this.initialize();
         return Promise.resolve();
     }
 
@@ -385,9 +391,9 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
             this.audio.removeAttribute('src');
             this.audio.load();
         }
-        this.audio = document.createElement('video');
+
         if (wasPlaying || forceAutoplay) {
-            this.audio.addEventListener('canplay', () => {
+            this.audio!.addEventListener('canplay', () => {
                 this.play();
             });
         }
@@ -407,7 +413,7 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
 
             //this.registerHlsListeners(hls, position);
         } else {
-            this.audio.src = item.assetUrl;
+            this.audio!.src = item.assetUrl;
         }
 
         await this.registerHtmlListeners(position);

--- a/src/web.ts
+++ b/src/web.ts
@@ -102,7 +102,7 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
     async create(): Promise<void> {
         this.audio = document.createElement('audio');
         this.audio.crossOrigin = 'anonymous';
-        this.audio.preload = 'none';
+        this.audio.preload = 'metadata';
         this.audio.controls = true;
         this.audio.autoplay = false;
         return Promise.resolve();
@@ -419,7 +419,10 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
         })
 
         if (wasPlaying || forceAutoplay) {
-            this.play();
+            //this.play();
+            this.audio!.addEventListener('canplay', () => {
+                this.play();
+            });
         }
     }
 


### PR DESCRIPTION
change video element to audio element

update properties for audio element

update initialize and release methods to be better aligned with the native functionality

FIXES: when audio duration is estimated (any time audio is transcoded on the fly) and the estimated duration does not exactly match the real duration (every time) the player would crash with a 416: range not available error.

After update playback runs smoothly as expected and playlist progresses as it should even when duration is estimated.

requires no changes to usage patterns or docs.