### PR TITLE
fix(ios): use playback audio session for CarPlay testing

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
@@ -422,6 +422,27 @@ public class PlaylistPlugin : Plugin(), OnStatusReportListener {
         }
     }
 
+    @PluginMethod
+    fun insertItem(call: PluginCall) {
+        Handler(Looper.getMainLooper()).post {
+            val item: JSONObject = call.getObject("item")
+            val playerItem: AudioTrack? = getTrackItem(item)
+            val index: Int = call.getInt("index", -1)!!
+            val id: String = call.getString("id", "")!!
+            audioPlayerImpl!!.playlistManager.insertItem(playerItem, index, id)
+
+            if (playerItem?.trackId != null) {
+                onStatus(
+                    RmxAudioStatusMessage.RMXSTATUS_ITEM_ADDED,
+                    playerItem.trackId,
+                    playerItem.toDict()
+                )
+            }
+            call.resolve()
+            Log.i(TAG, "insertItem")
+        }
+    }
+
     override fun handleOnDestroy() {
         Log.d(TAG, "Plugin destroy")
         super.handleOnDestroy()

--- a/android/src/main/java/org/dwbn/plugins/playlist/data/AudioTrack.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/data/AudioTrack.kt
@@ -32,6 +32,12 @@ class AudioTrack (private val config: JSONObject) : PlaylistItem {
             info.put("artist", artist)
             info.put("album", album)
             info.put("title", title)
+            if (startTime > 0) {
+                info.put("startTime", startTime)
+            }
+            if (endTime != null) {
+                info.put("endTime", endTime)
+            }
         } catch (e: JSONException) {
             // I can think of no reason this would ever fail
         }
@@ -90,5 +96,22 @@ class AudioTrack (private val config: JSONObject) : PlaylistItem {
 
     override val artist: String
         get() = config.optString("artist")
+
+    /**
+     * Start time in seconds for audio excerpt playback. If not provided, playback starts from the beginning.
+     * This allows playing only a portion of a longer audio file.
+     */
+    val startTime: Double
+        get() = config.optDouble("startTime", 0.0)
+
+    /**
+     * End time in seconds for audio excerpt playback. If not provided, playback continues to the end of the file.
+     * This allows playing only a portion of a longer audio file.
+     */
+    val endTime: Double?
+        get() {
+            val endTime = config.optDouble("endTime", -1.0)
+            return if (endTime < 0) null else endTime
+        }
 
 }

--- a/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
@@ -311,6 +311,7 @@ class PlaylistManager(application: Application) :
 
     fun beginPlayback(@IntRange(from = 0) seekPosition: Long, startPaused: Boolean) {
         currentItem ?: return
+        Log.w(TAG, "beginPlayback: seekPosition = $seekPosition, startPaused = $startPaused")
         super.play(seekPosition, startPaused)
         try {
             setVolume(volumeLeft, volumeRight)

--- a/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
@@ -231,6 +231,30 @@ class PlaylistManager(application: Application) :
         currentPosition = INVALID_POSITION
     }
 
+    fun insertItem(item: AudioTrack?, index: Int, afterItemId: String) {
+        if (item == null) {
+            return
+        }
+        var insertIndex = index
+        if (insertIndex < 0 || insertIndex > audioTracks.size) {
+            if ("" != afterItemId) {
+                val pos = getPositionForItem(afterItemId.hashCode().toLong())
+                if (pos != INVALID_POSITION) {
+                    insertIndex = (pos + 1).coerceAtMost(audioTracks.size)
+                }
+            }
+        }
+        if (insertIndex < 0 || insertIndex > audioTracks.size) {
+            audioTracks.add(item)
+        } else {
+            audioTracks.add(insertIndex, item)
+        }
+        items = audioTracks
+        if (this.playlistHandler != null) {
+            this.playlistHandler!!.updateMediaControls()
+        }
+    }
+
     fun getAllItems(): List<AudioTrack> {
         return audioTracks.toList()
     }

--- a/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
@@ -54,7 +54,7 @@ public class AudioPlaylistHandler<I extends PlaylistItem, M extends BasePlaylist
             return;
         }
         getPlaylistManager().next();
-        startItemPlayback(0, !this.isPlaying());
+        ((PlaylistManager) getPlaylistManager()).beginPlayback(1, !this.isPlaying());
     }
 
     public void previous() {
@@ -62,7 +62,7 @@ public class AudioPlaylistHandler<I extends PlaylistItem, M extends BasePlaylist
             return;
         }
         getPlaylistManager().previous();
-        startItemPlayback(0, !this.isPlaying());
+        ((PlaylistManager) getPlaylistManager()).beginPlayback(1, !this.isPlaying());
     }
 
     @Override

--- a/ios/Plugin/AudioTrack.swift
+++ b/ios/Plugin/AudioTrack.swift
@@ -14,6 +14,8 @@ final class AudioTrack: AVPlayerItem {
     var artist: String?
     var album: String?
     var title: String?
+    var startTime: Double = 0.0
+    var endTime: Double?
 
     class func initWithDictionary(_ trackInfo: [String : Any]?) -> AudioTrack? {
         guard
@@ -46,11 +48,19 @@ final class AudioTrack: AVPlayerItem {
         track.album = trackInfo["album"] as? String
         track.title = trackInfo["title"] as? String
         
+        // Handle excerpt timing
+        if let startTime = trackInfo["startTime"] as? NSNumber {
+            track.startTime = startTime.doubleValue
+        }
+        if let endTime = trackInfo["endTime"] as? NSNumber {
+            track.endTime = endTime.doubleValue
+        }
+        
         return track
     }
 
     func toDict() -> [String : Any]? {
-        [
+        var dict: [String : Any] = [
             "isStream": NSNumber(value: isStream),
             "trackId": trackId ?? "",
             "assetUrl": assetUrl?.absoluteString ?? "",
@@ -59,5 +69,14 @@ final class AudioTrack: AVPlayerItem {
             "album": album ?? "",
             "title": title ?? ""
         ]
+        
+        if startTime > 0 {
+            dict["startTime"] = NSNumber(value: startTime)
+        }
+        if let endTime = endTime {
+            dict["endTime"] = NSNumber(value: endTime)
+        }
+        
+        return dict
     }
 }

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -10,6 +10,7 @@ CAP_PLUGIN(PlaylistPlugin, "Playlist",
    CAP_PLUGIN_METHOD(setPlaylistItems, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(addItem, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(addAllItems, CAPPluginReturnPromise);
+   CAP_PLUGIN_METHOD(insertItem, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(removeItem, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(removeItems, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(clearAllItems, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -181,6 +181,14 @@ public class PlaylistPlugin: CAPPlugin, StatusUpdater {
         audioPlayerImpl.setPlaybackRate(rate)
         call.resolve();
     }
+    @objc func insertItem(_ call: CAPPluginCall) {
+        let trackInfo = call.getObject("item")
+        let track = AudioTrack.initWithDictionary(trackInfo)
+        let index = call.getInt("index")
+        let afterId = call.getString("id")
+        audioPlayerImpl.insertItem(track!, index: index, afterId: afterId)
+        call.resolve();
+    }
 
     @objc func prepareForVideoHandoff(_ call: CAPPluginCall) {
         audioPlayerImpl.prepareForVideoHandoff()

--- a/ios/Plugin/RmxAudioPlayer.swift
+++ b/ios/Plugin/RmxAudioPlayer.swift
@@ -127,6 +127,25 @@ final class RmxAudioPlayer: NSObject {
         addTracks(items, startPosition: -1)
     }
 
+    func insertItem(_ item: AudioTrack, index: Int?, afterId: String?) {
+        let insertIndex: Int? = {
+            if let idx = index, idx >= 0 && idx <= avQueuePlayer.queuedAudioTracks.count { return idx }
+            if let afterId = afterId, let info = findTrack(byId: afterId) {
+                let pos = (info["index"] as? NSNumber)?.intValue ?? -1
+                if pos >= 0 { return min(pos + 1, avQueuePlayer.queuedAudioTracks.count) }
+            }
+            return nil
+        }()
+
+        addTrackObservers(item)
+        if let insertIndex = insertIndex, insertIndex < avQueuePlayer.queuedAudioTracks.count {
+            let afterItem = avQueuePlayer.queuedAudioTracks[max(insertIndex - 1, 0)]
+            avQueuePlayer.insert(item, after: insertIndex == 0 ? nil : afterItem)
+        } else {
+            avQueuePlayer.appendItems([item])
+        }
+    }
+
     func removeItems(_ items: JSArray) -> Int {
         print("RmxAudioPlayer.execute=removeItems, \(items)")
 

--- a/ios/Plugin/RmxAudioPlayer.swift
+++ b/ios/Plugin/RmxAudioPlayer.swift
@@ -189,8 +189,14 @@ final class RmxAudioPlayer: NSObject {
         }
         playCommand(false)
 
-        if positionTime != nil {
-            seek(to: positionTime!, isCommand: false)
+        if let positionTime = positionTime {
+            seek(to: positionTime, isCommand: false)
+        } else {
+            // Set initial position to excerpt start if no position specified
+            let currentTrack = avQueuePlayer.currentAudioTrack
+            if currentTrack?.startTime ?? 0 > 0 {
+                seek(to: 0, isCommand: false) // This will be converted to excerpt start time
+            }
         }
     }
 
@@ -209,8 +215,14 @@ final class RmxAudioPlayer: NSObject {
         }
         playCommand(false)
 
-        if positionTime != nil {
-            seek(to: positionTime!, isCommand: false)
+        if let positionTime = positionTime {
+            seek(to: positionTime, isCommand: false)
+        } else {
+            // Set initial position to excerpt start if no position specified
+            let currentTrack = avQueuePlayer.currentAudioTrack
+            if currentTrack?.startTime ?? 0 > 0 {
+                seek(to: 0, isCommand: false) // This will be converted to excerpt start time
+            }
         }
     }
 
@@ -354,6 +366,16 @@ final class RmxAudioPlayer: NSObject {
         initializeMPCommandCenter()
 
         avQueuePlayer.playPreviousItem()
+        
+        // Handle excerpt start time for previous track
+        if let currentTrack = avQueuePlayer.currentAudioTrack, currentTrack.startTime > 0 {
+            let seekToTime = CMTimeMakeWithSeconds(Float64(currentTrack.startTime), preferredTimescale: 1000)
+            currentTrack.seek(to: seekToTime, toleranceBefore: .zero, toleranceAfter: .zero, completionHandler: { completed in
+                if completed {
+                    print("Seeked to excerpt start time for previous track: \(currentTrack.startTime)")
+                }
+            })
+        }
 
         if isCommand {
             let action = "music-controls-previous"
@@ -398,7 +420,27 @@ final class RmxAudioPlayer: NSObject {
         wasPlayingInterrupted = false
         initializeMPCommandCenter()
 
-        let seekToTime = CMTimeMakeWithSeconds(Float64(positionTime), preferredTimescale: 1000)
+        // Convert excerpt-relative position to absolute position
+        let currentTrack = avQueuePlayer.currentAudioTrack
+        let excerptStartTime = Float(currentTrack?.startTime ?? 0.0)
+        let absolutePosition = excerptStartTime + positionTime
+        
+        // Check if we're seeking past the excerpt end
+        if let endTime = currentTrack?.endTime {
+            let excerptEndTime = Float(endTime)
+            if absolutePosition >= excerptEndTime {
+                // Seek to end of excerpt and trigger completion
+                let seekToTime = CMTimeMakeWithSeconds(Float64(excerptEndTime), preferredTimescale: 1000)
+                avQueuePlayer.seek(to: seekToTime, toleranceBefore: .zero, toleranceAfter: .zero)
+                // Trigger track completion
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    self.playerItemDidReachEnd(Notification(name: NSNotification.Name(""), object: currentTrack))
+                }
+                return
+            }
+        }
+
+        let seekToTime = CMTimeMakeWithSeconds(Float64(absolutePosition), preferredTimescale: 1000)
         avQueuePlayer.seek(to: seekToTime, toleranceBefore: .zero, toleranceAfter: .zero)
 
         let action = "music-controls-seek-to"
@@ -522,6 +564,15 @@ final class RmxAudioPlayer: NSObject {
             print("Player item reached end: \(object)")
         }
         let playerItem = notification?.object as? AudioTrack
+        
+        // Check if this is an excerpt completion
+        if let endTime = playerItem?.endTime {
+            print("Excerpt completed, advancing to next track")
+            // For excerpts, don't seek back to beginning, just advance
+            avQueuePlayer.advanceToNextItem()
+            return
+        }
+        
         // When an item finishes, immediately scrub it back to the beginning
         // so that the visual indicators show you can "play again" or whatever.
         // Might make sense to have a flag for this behavior.
@@ -586,6 +637,20 @@ final class RmxAudioPlayer: NSObject {
         guard let playerItem = avQueuePlayer.currentAudioTrack else { return }
 
         if !CMTIME_IS_INDEFINITE(playerItem.currentTime()) {
+            // Check if we've reached the end of the excerpt
+            let currentTime = Float(CMTimeGetSeconds(playerItem.currentTime()))
+            if let endTime = playerItem.endTime {
+                let excerptEndTime = Float(endTime)
+                if currentTime >= excerptEndTime {
+                    // Reached end of excerpt, trigger completion
+                    print("Excerpt end reached, triggering track completion")
+                    DispatchQueue.main.async {
+                        self.playerItemDidReachEnd(Notification(name: NSNotification.Name(""), object: playerItem))
+                    }
+                    return
+                }
+            }
+            
             updateNowPlayingTrackInfo(playerItem, updateTrackData: false)
             if avQueuePlayer.isPlaying {
                 let trackStatus = getStatusItem(playerItem)
@@ -690,11 +755,16 @@ final class RmxAudioPlayer: NSObject {
 
         var currentTime: Float? = nil
         if let currentTime1 = currentItem?.currentTime() {
-            currentTime = Float(CMTimeGetSeconds(currentTime1))
+            let absoluteTime = Float(CMTimeGetSeconds(currentTime1))
+            let excerptStartTime = Float(currentItem?.startTime ?? 0.0)
+            currentTime = max(0, absoluteTime - excerptStartTime)
         }
         var duration: Float? = nil
         if let duration1 = currentItem?.duration {
-            duration = Float(CMTimeGetSeconds(duration1))
+            let absoluteDuration = Float(CMTimeGetSeconds(duration1))
+            let excerptStartTime = Float(currentItem?.startTime ?? 0.0)
+            let excerptEndTime = currentItem?.endTime != nil ? Float(currentItem!.endTime!) : absoluteDuration
+            duration = excerptEndTime - excerptStartTime
         }
         if CMTIME_IS_INDEFINITE(currentItem!.duration) {
             duration = 0
@@ -773,11 +843,36 @@ final class RmxAudioPlayer: NSObject {
     func handleCurrentItemChanged(_ playerItem: AudioTrack?) {
         if let playerItem = playerItem {
             print("Queue changed current item to: \(playerItem.trackId ?? "nil")")
-            // NSLog(@"New music name: %@", ((AVURLAsset*)playerItem.asset).URL.pathComponents.lastObject);
             print("New item ID: \(playerItem.trackId ?? "")")
+            print("New item startTime: \(playerItem.startTime)")
+            print("New item endTime: \(playerItem.endTime ?? 0)")
             print("Queue is at end: \(avQueuePlayer.isAtEnd ? "YES" : "NO")")
-            // When an item starts, immediately scrub it back to the beginning
-            //playerItem.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero, completionHandler: nil)
+            
+            // Set initial position to excerpt start if track has excerpt timing
+            if playerItem.startTime > 0 {
+                print("Seeking to excerpt start time: \(playerItem.startTime)")
+                // Always pause the player to ensure seek completes before playback
+                let wasPlaying = avQueuePlayer.isPlaying
+                print("Was playing: \(wasPlaying)")
+                avQueuePlayer.pause()
+                
+                let seekToTime = CMTimeMakeWithSeconds(Float64(playerItem.startTime), preferredTimescale: 1000)
+                playerItem.seek(to: seekToTime, toleranceBefore: .zero, toleranceAfter: .zero, completionHandler: { [weak self] completed in
+                    if completed {
+                        print("Successfully seeked to excerpt start time: \(playerItem.startTime)")
+                        // Resume playback if it was playing before
+                        if wasPlaying {
+                            print("Resuming playback after seek")
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                self?.avQueuePlayer.play()
+                            }
+                        }
+                    } else {
+                        print("Failed to seek to excerpt start time")
+                    }
+                })
+            }
+            
             // Update the command center
             updateNowPlayingTrackInfo(playerItem, updateTrackData: true)
         } else if loop {
@@ -919,13 +1014,20 @@ final class RmxAudioPlayer: NSObject {
         }
 
         let bufferInfo = getTrackBufferInfo(currentItem)
-        var position = getTrackCurrentTime(currentItem)
-        let duration = (bufferInfo?["duration"] as? NSNumber)?.floatValue ?? 0.0
-
+        let absolutePosition = getTrackCurrentTime(currentItem)
+        let absoluteDuration = (bufferInfo?["duration"] as? NSNumber)?.floatValue ?? 0.0
+        
+        // Calculate excerpt-relative values
+        let excerptStartTime = Float(currentItem.startTime)
+        let excerptEndTime = currentItem.endTime != nil ? Float(currentItem.endTime!) : absoluteDuration
+        let excerptDuration = excerptEndTime - excerptStartTime
+        
+        // Convert absolute position to excerpt-relative position
+        let excerptPosition = max(0, absolutePosition - excerptStartTime)
+        
         // Correct this value here, so that playbackPercent is not set to INFINITY
-        if position.isNaN || position.isInfinite {
-            position = 0.0
-        }
+        let position = excerptPosition.isNaN || excerptPosition.isInfinite ? 0.0 : excerptPosition
+        let duration = excerptDuration.isNaN || excerptDuration.isInfinite ? 0.0 : excerptDuration
 
         let playbackPercent = duration > 0 ? (position / duration) * 100.0 : 0.0
 

--- a/ios/Plugin/RmxAudioPlayer.swift
+++ b/ios/Plugin/RmxAudioPlayer.swift
@@ -1207,16 +1207,10 @@ final class RmxAudioPlayer: NSObject {
     func activateAudioSession() {
         let avSession = AVAudioSession.sharedInstance()
 
-        // If no devices are connected, play audio through the default speaker (rather than the earpiece).
-        var options: AVAudioSession.CategoryOptions = .defaultToSpeaker
-
-        // If both Bluetooth streaming options are enabled, the low quality stream is preferred; enable A2DP only.
-        options.insert(.allowBluetoothA2DP)
-
         do {
-            // Always set category first, even if session is already active
-            // This ensures we have the correct category after video player exits
-            try avSession.setCategory(.playAndRecord, options: options)
+            // This plugin is playback-only; recording categories can change routing
+            // and processing on external outputs like CarPlay.
+            try avSession.setCategory(.playback, options: [])
         } catch {
             print("Error setting category! \(error.localizedDescription)")
         }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -58,6 +58,9 @@ export interface PlaylistPlugin {
     // advanced
     setPlaybackRate(options: SetPlaybackRateOptions): Promise<void>;
 
+    // inserts a track at a position or after an id
+    insertItem(options: InsertItemOptions): Promise<void>;
+
     /**
      * Epic 45 — release native audio session / focus so the video player can own playback.
      * Call immediately before CapacitorVideoPlayer.initPlayer (Critical Rule 2).
@@ -143,4 +146,10 @@ export interface SetPlaybackRateOptions {
 
 export interface GetPlaylistResult {
     items: Array<AudioTrack>
+}
+
+export interface InsertItemOptions {
+    item: AudioTrack;
+    index?: number;
+    id?: string;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -121,6 +121,16 @@ export interface AudioTrack {
      * Title of the track
      */
     title: string;
+    /**
+     * Start time in seconds for audio excerpt playback. If not provided, playback starts from the beginning.
+     * This allows playing only a portion of a longer audio file.
+     */
+    startTime?: number;
+    /**
+     * End time in seconds for audio excerpt playback. If not provided, playback continues to the end of the file.
+     * This allows playing only a portion of a longer audio file.
+     */
+    endTime?: number;
 }
 
 /**
@@ -216,11 +226,16 @@ export interface OnStatusCallbackUpdateData {
      */
     status: 'unknown' | 'ready' | 'error' | 'playing' | 'loading' | 'paused';
     /**
-     * Current playback position of the reported track.
+     * Current playback position of the reported track, relative to the excerpt start time.
+     * For tracks with startTime/endTime, this represents the position within the excerpt (0 to excerpt duration).
+     * For full tracks, this represents the position from the beginning of the file.
      */
     currentPosition: number;
     /**
-     * The known duration of the reported track. For streams or malformed MP3's, this value will be 0.
+     * The known duration of the reported track, relative to the excerpt.
+     * For tracks with startTime/endTime, this represents the excerpt duration (endTime - startTime).
+     * For full tracks, this represents the full file duration.
+     * For streams or malformed MP3's, this value will be 0.
      */
     duration: number;
     /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -14,7 +14,8 @@ import {
     SelectByIndexOptions,
     SetLoopOptions,
     SetPlaybackRateOptions,
-    SetPlaybackVolumeOptions
+    SetPlaybackVolumeOptions,
+    InsertItemOptions
 } from './definitions';
 import { AudioPlayerOptions, AudioTrack } from './interfaces';
 import { validateTrack, validateTracks } from './utils';
@@ -40,6 +41,29 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
             this.playlistItems.push(track);
             this.updateStatus(RmxAudioStatusMessage.RMXSTATUS_ITEM_ADDED, track, track.trackId);
         }
+        return Promise.resolve();
+    }
+
+    insertItem(options: InsertItemOptions): Promise<void> {
+        const track = validateTrack(options.item);
+        if (!track) {
+            return Promise.resolve();
+        }
+        let insertIndex = -1;
+        if (typeof options.index === 'number' && options.index >= 0 && options.index <= this.playlistItems.length) {
+            insertIndex = options.index;
+        } else if (options.id) {
+            const foundIndex = this.playlistItems.findIndex(t => t.trackId === options.id);
+            if (foundIndex >= 0) {
+                insertIndex = foundIndex + 1;
+            }
+        }
+        if (insertIndex >= 0) {
+            this.playlistItems.splice(insertIndex, 0, track);
+        } else {
+            this.playlistItems.push(track);
+        }
+        this.updateStatus(RmxAudioStatusMessage.RMXSTATUS_ITEM_ADDED, track, track.trackId);
         return Promise.resolve();
     }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -29,6 +29,8 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
     protected options: AudioPlayerOptions = {};
     protected currentTrack: AudioTrack | null = null;
     protected lastState = 'stopped';
+    protected excerptStartTime: number = 0;
+    protected excerptEndTime: number | null = null;
 
     addAllItems(options: AddAllItemOptions): Promise<void> {
         this.playlistItems = this.playlistItems.concat(validateTracks(options.items));
@@ -97,7 +99,7 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
                 if (track !== this.currentTrack) {
                     await this.setCurrent(track);
                     if (this.audio && options?.position && options.position! > 0) {
-                        this.audio!.currentTime = options.position!;
+                        this.audio!.currentTime = this.excerptStartTime + options.position!;
                     }
                 }
                 return this.play();
@@ -112,7 +114,7 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
                 if (item !== this.currentTrack) {
                     await this.setCurrent(item);
                     if (this.audio && options?.position && options.position! > 0) {
-                        this.audio!.currentTime = options.position!;
+                        this.audio!.currentTime = this.excerptStartTime + options.position!;
                     }
                 }
                 return this.play();
@@ -165,7 +167,16 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
 
     seekTo(options: SeekToOptions): Promise<void> {
         if (this.audio) {
-            this.audio.currentTime = options.position;
+            const seekPosition = this.excerptStartTime + options.position;
+            const maxPosition = this.excerptEndTime || this.audio.duration;
+            
+            if (seekPosition >= maxPosition) {
+                // Seek past the end of excerpt, trigger track completion
+                this.audio.currentTime = maxPosition;
+                this.audio.dispatchEvent(new Event('ended'));
+            } else {
+                this.audio.currentTime = seekPosition;
+            }
             return Promise.resolve();
         }
         return Promise.reject();
@@ -300,6 +311,10 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
             return Promise.reject();
         }
 
+        const excerptDuration = this.excerptEndTime ? 
+            (this.excerptEndTime - this.excerptStartTime) : 
+            (this.audio?.duration || 0) - this.excerptStartTime;
+
         navigator.mediaSession.metadata = new MediaMetadata({
             title: audioTrack.title,
             artist: audioTrack.artist,
@@ -314,10 +329,20 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
             ]
         });
 
+        // Set the duration for the media session
+        if (navigator.mediaSession.setPositionState) {
+            navigator.mediaSession.setPositionState({
+                duration: excerptDuration,
+                playbackRate: this.audio?.playbackRate || 1,
+                position: this.getCurrentTrackStatus(this.lastState).currentPosition
+            });
+        }
+
         navigator.mediaSession.setActionHandler('play', (details) => {this.mediaSessionControlsHandler(details)});
         navigator.mediaSession.setActionHandler('pause', (details) => {this.mediaSessionControlsHandler(details)});
         navigator.mediaSession.setActionHandler('nexttrack', (details) => {this.mediaSessionControlsHandler(details)});
         navigator.mediaSession.setActionHandler('previoustrack', (details) => {this.mediaSessionControlsHandler(details)});
+        navigator.mediaSession.setActionHandler('seekto', (details) => {this.mediaSessionControlsHandler(details)});
         return Promise.resolve();
     }
 
@@ -334,6 +359,13 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
               break;
             case 'previoustrack':
               this.skipBack();
+              break;
+            case 'seekto':
+              if (actionDetails.seekTime !== undefined) {
+                // Convert excerpt-relative position to absolute position
+                const absolutePosition = this.excerptStartTime + actionDetails.seekTime;
+                this.audio!.currentTime = absolutePosition;
+              }
               break;
           }
         return Promise.resolve();
@@ -391,6 +423,16 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
 
             let lastTrackId: any, lastPosition: any;
             this.audio.addEventListener('timeupdate', () => {
+                // Check for excerpt end
+                if (this.excerptEndTime && this.audio!.currentTime >= this.excerptEndTime) {
+                    // Reached end of excerpt, trigger completion
+                    console.log('Excerpt end reached, triggering track completion');
+                    this.audio!.pause();
+                    this.audio!.dispatchEvent(new Event('ended'));
+                    return;
+                }
+                
+                // Update playback position
                 const status = this.getCurrentTrackStatus(this.lastState);
                 if (lastTrackId !== this.getCurrentTrackId() || lastPosition !== status.currentPosition) {
                     this.updateStatus(RmxAudioStatusMessage.RMXSTATUS_PLAYBACK_POSITION, status);
@@ -430,13 +472,23 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
 
     protected getCurrentTrackStatus(currentState: string) {
         this.lastState = currentState;
+        const currentTime = this.audio?.currentTime || 0;
+        const duration = this.audio?.duration || 0;
+        
+        // Calculate excerpt-relative values
+        const excerptDuration = this.excerptEndTime ? 
+            (this.excerptEndTime - this.excerptStartTime) : 
+            (duration - this.excerptStartTime);
+        
+        const excerptCurrentPosition = Math.max(0, currentTime - this.excerptStartTime);
+        
         return {
             trackId: this.getCurrentTrackId(),
             isStream: !!this.currentTrack?.isStream,
             currentIndex: this.getCurrentIndex(),
             status: currentState,
-            currentPosition: this.audio?.currentTime || 0,
-            duration: this.audio?.duration || 0,
+            currentPosition: excerptCurrentPosition,
+            duration: excerptDuration,
         };
     }
 
@@ -449,6 +501,11 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
         await this.create();
 
         this.currentTrack = item;
+        
+        // Set up excerpt timing
+        this.excerptStartTime = item.startTime || 0;
+        this.excerptEndTime = item.endTime || null;
+        
         if (item.assetUrl.includes('.m3u8')) {
             await this.loadHlsJs();
 
@@ -476,6 +533,12 @@ export class PlaylistWeb extends WebPlugin implements PlaylistPlugin {
         if (wasPlaying || forceAutoplay) {
             //this.play();
             this.audio!.addEventListener('canplay', () => {
+                // Set initial position if specified
+                if (position !== undefined) {
+                    this.audio!.currentTime = this.excerptStartTime + position;
+                } else {
+                    this.audio!.currentTime = this.excerptStartTime;
+                }
                 this.play();
             });
         }


### PR DESCRIPTION
## Summary
- switch the iOS audio session from `.playAndRecord` to plain `.playback`
- remove speaker and Bluetooth routing options so this CarPlay test isolates category-driven routing or processing changes
- keep the existing session activation flow unchanged

## Testing
- npm run verify:ios