### PR TITLE
playlist, ts: use canonical id/index removal contract

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
@@ -159,8 +159,8 @@ public class PlaylistPlugin : Plugin(), OnStatusReportListener {
             val removals = ArrayList<TrackRemovalItem>()
             for (index in 0 until items.length()) {
                 val entry = items.optJSONObject(index) ?: continue
-                val trackIndex = entry.optInt("trackIndex", -1)
-                val trackId = entry.optString("trackId", "")
+                val trackIndex = entry.optInt("index", -1)
+                val trackId = entry.optString("id", "")
                 removals.add(TrackRemovalItem(trackIndex, trackId))
             }
 

--- a/ios/Sources/PlaylistPlugin/RmxAudioPlayer.swift
+++ b/ios/Sources/PlaylistPlugin/RmxAudioPlayer.swift
@@ -161,16 +161,17 @@ final class RmxAudioPlayer: NSObject {
         var removed = 0
         if items.count > 0 {
             for item in items {
-                guard let item = item as? [String: String] else {
+                guard let item = item as? [String: Any] else {
                     continue
                 }
-                if let id = item["trackId"] {
+
+                if let id = item["id"] as? String {
                     do {
                         try removeItem(id)
                         removed += 1
                     } catch {}
                 }
-                else if let index = Int(item["trackIndex"]!) {
+                else if let index = (item["index"] as? NSNumber)?.intValue {
                     do {
                         try removeItem(index)
                         removed += 1

--- a/src/RmxAudioPlayer.ts
+++ b/src/RmxAudioPlayer.ts
@@ -3,9 +3,6 @@ import {
     RmxAudioStatusMessageDescriptions
 } from './Constants';
 import {
-    RemoveItemOptions
-} from './definitions';
-import {
     AudioPlayerEventHandler,
     AudioPlayerEventHandlers,
     AudioPlayerOptions,
@@ -206,17 +203,13 @@ export class RmxAudioPlayer {
         if (!removeItem) {
             throw new Error('Track removal spec is empty');
         }
-        if (!removeItem.trackId && !removeItem.trackIndex) {
+        if (!removeItem.trackId && removeItem.trackIndex === undefined) {
             throw new Error('Track removal spec is invalid');
         }
-        const opts: RemoveItemOptions = {};
-        if (removeItem.trackIndex !== undefined && removeItem.trackIndex !== null) {
-            opts.index = removeItem.trackIndex;
-        }
-        if (removeItem.trackId) {
-            opts.id = removeItem.trackId;
-        }
-        return Playlist.removeItem(opts);
+        return Playlist.removeItem({
+            id: removeItem.trackId,
+            index: removeItem.trackIndex
+        });
     };
 
     /**
@@ -224,11 +217,12 @@ export class RmxAudioPlayer {
      * include the currently playing item, the next available item will automatically begin playing.
      */
     removeItems = (items: AudioTrackRemoval[]) => {
-        const mapped: RemoveItemOptions[] = (items || []).map((item) => ({
-            id: item?.trackId,
-            index: item?.trackIndex
-        }));
-        return Playlist.removeItems({items: mapped});
+        return Playlist.removeItems({
+            items: (items || []).map((item) => ({
+                id: item?.trackId,
+                index: item?.trackIndex
+            }))
+        });
     };
 
     /**


### PR DESCRIPTION
* **Android:** `removeItems()` now reads the documented low-level fields `index` and `id`, rather than the incompatible legacy names `trackIndex` and `trackId`.
* **iOS:** batch entries are decoded as `[String: Any]`, allowing numeric indices from JSON, and use the canonical `id`/`index` fields. The previous `[String: String]` cast prevented normal numeric indices from being recognized.
* **TypeScript wrapper:** `trackIndex: 0` is no longer rejected as falsy, and the legacy high-level wrapper fields are mapped cleanly to the canonical plugin contract.
