### PR TITLE
fix(ios): pass setOptions payload as JSObject

### DIFF
--- a/ios/Sources/PlaylistPlugin/Plugin.swift
+++ b/ios/Sources/PlaylistPlugin/Plugin.swift
@@ -50,7 +50,7 @@ public class PlaylistPlugin: CAPPlugin, StatusUpdater, CAPBridgedPlugin {
     }
     @objc func setOptions(_ call: CAPPluginCall) {
         // setOptions is invoked with the full payload as the options object.
-        audioPlayerImpl.setOptions(call.options as! [String : Any])
+        audioPlayerImpl.setOptions(call.jsObjectRepresentation)
         call.resolve()
     }
     @objc func release(_ call: CAPPluginCall) {


### PR DESCRIPTION
Use Capacitor's typed JavaScript object representation instead of force-casting the bridged NSDictionary payload.