### PR TITLE
fix(android): remove custom application requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,15 @@ Add to `angular.json` → architect → build → options → scripts:
 ```xml
 <uses-permission android:name="android.permission.WAKE_LOCK" />
 <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
-<application android:name="org.dwbn.plugins.playlist.App">
+<application>
     <service android:enabled="true" android:exported="false"
              android:foregroundServiceType="mediaPlayback"
              android:name="org.dwbn.plugins.playlist.service.MediaService">
     </service>
 </application>
 ```
+
+Keep your application's existing Android `Application` class. The legacy `org.dwbn.plugins.playlist.App` class remains available for compatibility, but it is no longer required.
 
 #### Gradle 9+
 

--- a/android/src/main/java/org/dwbn/plugins/playlist/App.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/App.kt
@@ -1,19 +1,6 @@
 package org.dwbn.plugins.playlist
 
 import android.app.Application
-import org.dwbn.plugins.playlist.manager.PlaylistManager
 
-class App : Application() {
-    private lateinit var _playlistManager: PlaylistManager;
-    val playlistManager get() = _playlistManager
-
-    fun resetPlaylistManager() {
-        _playlistManager = PlaylistManager(this)
-    }
-
-    override fun onCreate() {
-        resetPlaylistManager()
-        super.onCreate()
-
-    }
-}
+@Deprecated("No longer required; use your app's existing Application class")
+class App : Application()

--- a/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
@@ -22,7 +22,7 @@ public class PlaylistPlugin : Plugin(), OnStatusReportListener {
     private var isWebViewActive = true
 
     override fun load() {
-        audioPlayerImpl = RmxAudioPlayer(this, (this.context.applicationContext as App))
+        audioPlayerImpl = RmxAudioPlayer(this, context.applicationContext)
     }
 
     @PluginMethod

--- a/android/src/main/java/org/dwbn/plugins/playlist/PlaylistRuntime.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/PlaylistRuntime.kt
@@ -1,0 +1,16 @@
+package org.dwbn.plugins.playlist
+
+import android.app.Application
+import android.content.Context
+import org.dwbn.plugins.playlist.manager.PlaylistManager
+
+object PlaylistRuntime {
+    private var playlistManager: PlaylistManager? = null
+
+    @JvmStatic
+    fun getPlaylistManager(context: Context): PlaylistManager = synchronized(this) {
+        playlistManager ?: PlaylistManager(context.applicationContext as Application).also {
+            playlistManager = it
+        }
+    }
+}

--- a/android/src/main/java/org/dwbn/plugins/playlist/RmxAudioPlayer.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/RmxAudioPlayer.java
@@ -1,5 +1,6 @@
 package org.dwbn.plugins.playlist;
 
+import android.content.Context;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -39,16 +40,16 @@ public class RmxAudioPlayer implements PlaybackStatusListener<AudioTrack>,
     // It would be used to switch between playlists. I guess we could
     // support that in the future, might be cool.
     private static final int PLAYLIST_ID = 32;
-    private PlaylistManager playlistManager;
+    private final PlaylistManager playlistManager;
     private final OnStatusReportListener statusListener;
 
     private int lastBufferPercent = 0;
     private long lastDuration = 0;
     private boolean trackLoaded = false;
     private boolean resetStreamOnPause = true;
-    private final App app;
+    private final Context context;
 
-    public RmxAudioPlayer(@NonNull OnStatusReportListener statusListener, App context) {
+    public RmxAudioPlayer(@NonNull OnStatusReportListener statusListener, @NonNull Context context) {
         // AudioPlayerPlugin and RmxAudioPlayer are separate classes in order to increase
         // the portability of this code.
         // Because AudioPlayerPlugin itself holds a strong reference to this class,
@@ -56,10 +57,9 @@ public class RmxAudioPlayer implements PlaybackStatusListener<AudioTrack>,
         // but these two objects will always live together (And the plugin couldn't function
         // at all if this one gets garbage collected).
         this.statusListener = statusListener;
-        this.app = context;
+        this.context = context.getApplicationContext();
+        this.playlistManager = PlaylistRuntime.getPlaylistManager(this.context);
 
-        app.resetPlaylistManager();
-        getPlaylistManager();
         playlistManager.setId(PLAYLIST_ID);
         playlistManager.setPlaybackStatusListener(this);
         playlistManager.setOnErrorListener(this);
@@ -67,7 +67,6 @@ public class RmxAudioPlayer implements PlaybackStatusListener<AudioTrack>,
     }
 
     public PlaylistManager getPlaylistManager() {
-        playlistManager = app.getPlaylistManager();
         return playlistManager;
     }
 
@@ -81,7 +80,7 @@ public class RmxAudioPlayer implements PlaybackStatusListener<AudioTrack>,
     }
 
     public void setOptions(JSONObject val) {
-        Options options = new Options(app, val);
+        Options options = new Options(context, val);
         getPlaylistManager().setOptions(options);
     }
 
@@ -412,7 +411,6 @@ public class RmxAudioPlayer implements PlaybackStatusListener<AudioTrack>,
 
     public void resume() {
         Log.i(TAG, "Resumed, wiring up event listeners");
-        getPlaylistManager();
         registerPlaylistListeners();
         //Makes sure to retrieve the current playback information
         updateCurrentPlaybackInformation();

--- a/android/src/main/java/org/dwbn/plugins/playlist/service/MediaService.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/service/MediaService.kt
@@ -8,7 +8,7 @@ import android.os.Build
 import android.util.Log
 import com.devbrackets.android.playlistcore.components.playlisthandler.PlaylistHandler
 import com.devbrackets.android.playlistcore.service.BasePlaylistService
-import org.dwbn.plugins.playlist.App
+import org.dwbn.plugins.playlist.PlaylistRuntime
 import org.dwbn.plugins.playlist.data.AudioTrack
 import org.dwbn.plugins.playlist.manager.PlaylistManager
 import org.dwbn.plugins.playlist.playlist.AudioApi
@@ -97,7 +97,7 @@ class MediaService : BasePlaylistService<AudioTrack, PlaylistManager>() {
     fun isRunningInForeground(): Boolean = inForeground
 
     override val playlistManager: PlaylistManager
-        get() = (applicationContext as App).playlistManager
+        get() = PlaylistRuntime.getPlaylistManager(applicationContext)
 
     override fun newPlaylistHandler(): PlaylistHandler<AudioTrack> {
         val imageProvider = MediaImageProvider(applicationContext, object : OnImageUpdatedListener {


### PR DESCRIPTION
## Summary

- share the playlist manager through a process-level runtime owner using the host application context
- remove the requirement for host apps to subclass the plugin Application
- retain the old App class as a deprecated compatibility shim and update the README

## Why

The plugin and media service currently depend on the host application being org.dwbn.plugins.playlist.App. Ordinary Capacitor applications can therefore crash on forced casts, and replacing the plugin instance can lose access to playback state.

## Validation

Validated in Faidah, a Capacitor 8 Android host using AGP 8.13.0, Kotlin 2.2.20, and mise-managed OpenJDK 21.

- The plugin Gradle build passed for debug and release, including Kotlin/Java compilation, unit tests, lint, and AAR assembly.
- Removed android:name="org.dwbn.plugins.playlist.App" from the host manifest and ran :app:assembleDebug.
- The host debug APK assembled successfully without the plugin Application subclass.