### PR TITLE
fix(android): declare the media playback service

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,13 @@
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
+    <application>
+        <service
+            android:name="org.dwbn.plugins.playlist.service.MediaService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
+    </application>
 </manifest>


### PR DESCRIPTION
## Summary

- declare the plugin-owned MediaService in the library manifest
- add the wake-lock and foreground-service permissions required for media playback
- keep the service private to the host app and identify it as a media-playback foreground service

## Why

Host applications should receive the service declaration and required permissions through manifest merging. Without them, Android playback can fail when the plugin starts its foreground media service.

## Validation

Validated in Faidah, a Capacitor 8 Android host using AGP 8.13.0, Kotlin 2.2.20, and mise-managed OpenJDK 21.

- The plugin Gradle build passed for debug and release, including Kotlin/Java compilation, unit tests, lint, and AAR assembly.
- Removed the manual MediaService and permission declarations from the Faidah host, then ran :app:processDebugMainManifest.
- The app-level merge succeeded and produced exactly one MediaService with exported=false and foregroundServiceType=mediaPlayback.
- The merged manifest contains WAKE_LOCK, FOREGROUND_SERVICE, and FOREGROUND_SERVICE_MEDIA_PLAYBACK; the release AAR contains the same declarations.