### PR TITLE
fix(android): separate playlist identity from track ids

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
@@ -311,13 +311,16 @@ public class PlaylistPlugin : Plugin(), OnStatusReportListener {
         Handler(Looper.getMainLooper()).post {
             val id: String = call.getString("id")!!
             if ("" != id) {
-                val code = id.hashCode()
-                val seekPosition = (call.getFloat("position", 0f)!! * 1000.0f).toLong()
-                audioPlayerImpl!!.playlistManager.setCurrentItem(code.toLong())
-                val handler = audioPlayerImpl!!.playlistManager.playlistHandler
-                val alreadyPlaying = handler?.currentMediaPlayer?.isPlaying == true
-                if (!audioPlayerImpl!!.tryResumeVideoHandoffInPlace(seekPosition) && !alreadyPlaying) {
-                    audioPlayerImpl!!.playlistManager.beginPlayback(seekPosition, false)
+                val playlistManager = audioPlayerImpl!!.playlistManager
+                val position = playlistManager.findTrackPosition(id)
+                if (position >= 0) {
+                    val seekPosition = (call.getFloat("position", 0f)!! * 1000.0f).toLong()
+                    playlistManager.currentPosition = position
+                    val handler = playlistManager.playlistHandler
+                    val alreadyPlaying = handler?.currentMediaPlayer?.isPlaying == true
+                    if (!audioPlayerImpl!!.tryResumeVideoHandoffInPlace(seekPosition) && !alreadyPlaying) {
+                        playlistManager.beginPlayback(seekPosition, false)
+                    }
                 }
             }
 
@@ -351,13 +354,13 @@ public class PlaylistPlugin : Plugin(), OnStatusReportListener {
         Handler(Looper.getMainLooper()).post {
             val id: String = call.getString("id")!!
             if ("" != id) {
-                // alternatively we could search for the item and set the current index to that item.
-                val code = id.hashCode()
-                audioPlayerImpl!!.playlistManager.setCurrentItem(code.toLong())
-
-                val seekPosition = (call.getFloat("position", 0f)!! * 1000.0f).toLong()
-
-                audioPlayerImpl!!.playlistManager.beginPlayback(seekPosition, true)
+                val playlistManager = audioPlayerImpl!!.playlistManager
+                val position = playlistManager.findTrackPosition(id)
+                if (position >= 0) {
+                    val seekPosition = (call.getFloat("position", 0f)!! * 1000.0f).toLong()
+                    playlistManager.currentPosition = position
+                    playlistManager.beginPlayback(seekPosition, true)
+                }
             }
             call.resolve()
 

--- a/android/src/main/java/org/dwbn/plugins/playlist/data/AudioTrack.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/data/AudioTrack.kt
@@ -5,8 +5,15 @@ import com.devbrackets.android.playlistcore.api.PlaylistItem
 import com.devbrackets.android.playlistcore.manager.BasePlaylistManager
 import org.json.JSONException
 import org.json.JSONObject
+import java.util.concurrent.atomic.AtomicLong
 
 class AudioTrack (private val config: JSONObject) : PlaylistItem {
+    companion object {
+        private val nextPlaylistId = AtomicLong(1)
+    }
+
+    override val id: Long = nextPlaylistId.getAndIncrement()
+
     var bufferPercentFloat = 0f
         set(buff) {
             // There is a bug in MediaProgress where if bufferPercent == 100 it sets bufferPercentFloat
@@ -37,12 +44,6 @@ class AudioTrack (private val config: JSONObject) : PlaylistItem {
         }
         return info
     }
-
-    override val id: Long
-        get() =
-            if (trackId == null) {
-                0
-            } else trackId.hashCode().toLong()
 
     val isStream: Boolean
         get() = config.optBoolean("isStream", false)

--- a/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
@@ -118,14 +118,12 @@ class PlaylistManager(application: Application) :
             }
         }
 
-        // If the options said to start from a specific id, do so.
-        var idStart: String? = null
-        if (options.playFromId != null) {
-            idStart = options.playFromId
-        }
-        if (idStart != null && "" != idStart) {
-            val code = idStart.hashCode()
-            setCurrentItem(code.toLong())
+        // If the requested id exists, start there; otherwise keep the first track.
+        options.playFromId?.let { trackId ->
+            val position = findTrackPosition(trackId)
+            if (position != INVALID_POSITION) {
+                currentPosition = position
+            }
         }
 
         // We assume that if the playlist is fully loaded in one go,
@@ -307,17 +305,15 @@ class PlaylistManager(application: Application) :
     }
 
     private fun resolveItemPosition(trackIndex: Int, trackId: String): Int {
-        var resolvedPosition = -1
-        if (trackIndex >= 0 && trackIndex < audioTracks.size) {
-            resolvedPosition = trackIndex
-        } else if ("" != trackId) {
-            val itemPos = getPositionForItem(trackId.hashCode().toLong())
-            if (itemPos != INVALID_POSITION) {
-                resolvedPosition = itemPos
-            }
+        return when {
+            trackIndex in audioTracks.indices -> trackIndex
+            trackId.isNotEmpty() -> findTrackPosition(trackId)
+            else -> INVALID_POSITION
         }
-        return resolvedPosition
     }
+
+    internal fun findTrackPosition(trackId: String): Int =
+        audioTracks.indexOfFirst { it.trackId == trackId }
 
     fun getVolumeLeft(): Float {
         return volumeLeft


### PR DESCRIPTION
## Summary

- give every `AudioTrack` instance a collision-free internal ID for PlaylistCore
- keep public `trackId` values as strings and resolve them by exact comparison
- use exact public-ID lookup for playlist startup, playback, selection, removal, and replacement

## Why

PlaylistCore requires a numeric identity per playlist item, but the plugin currently derives it from Java `String.hashCode()`. Different public IDs can therefore become the same native item (`FB` and `Ea` both hash to `2236`), while duplicate public IDs are also forced to share one internal identity. That can select or remove the wrong item and makes native identity depend on a lossy conversion of the public API.

## Validation

Replayed the reviewed one-commit patch onto current upstream `main` at `51ff36c` (v0.11.1), after the new indexed add/move/replace work landed.

- `git range-diff` reports the replayed patch unchanged.
- GitHub compare reports one commit, zero commits behind, and only the three intended Android files.
- `mise x node@24 java@openjdk-21 -- npm run verify:android` completed all 158 Gradle tasks: debug/release Kotlin and Java compilation, unit tests, lint, checks, and AAR assembly.
- The newly added upstream move/replace unit tests pass with exact string lookup in `resolveItemPosition()`.
- The same production implementation is exercised by Rawy's Android native smoke on an emulator with the real collision pair `FB`/`Ea`; it selected `Ea` after playing `FB` and completed the subsequent pause/seek/resume transition successfully.
