### PR TITLE
fix(android): retain position when replacing playlist

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
@@ -104,19 +104,15 @@ class PlaylistManager(application: Application) :
      * List management
      */
     fun setAllItems(items: List<AudioTrack>?, options: PlaylistItemOptions) {
+        val seekStart = when {
+            options.playFromPosition >= 0 -> options.playFromPosition
+            options.retainPosition -> currentProgress?.position ?: 0
+            else -> 0
+        }
+
         clearItems()
         addAllItems(items)
         currentPosition = 0
-        // If the options said to start from a specific position, do so.
-        var seekStart: Long = 0
-        if (options.playFromPosition > 0) {
-            seekStart = options.playFromPosition
-        } else if (options.retainPosition) {
-            val progress = currentProgress
-            if (progress != null) {
-              seekStart = progress.position
-            }
-        }
 
         // If the options said to start from a specific id, do so.
         var idStart: String? = null


### PR DESCRIPTION
## Summary

- capture the active playback position before clearing the old playlist
- preserve an explicit `playFromPosition`, including zero
- use retained progress only when no explicit position was supplied

## Why

`setAllItems()` currently calls `clearItems()` before reading `currentProgress`, so `retainPosition: true` can only observe cleared state. It also treats `playFromPosition: 0` as if the option were absent, allowing retained progress to override an explicit request to start at the beginning.

## Validation

Replayed the reviewed one-commit patch onto current upstream `main` at `51ff36c` (v0.11.1), including the maintainer's new indexed add/move/replace work.

- `git range-diff` reports the replayed patch unchanged.
- GitHub compare reports one commit, zero commits behind, and a single intended file: `PlaylistManager.kt`.
- `mise x node@24 java@openjdk-21 -- npm run verify:android` completed all 158 Gradle tasks: debug/release Kotlin and Java compilation, unit tests, lint, checks, and AAR assembly.
- The resulting precedence is explicit and evaluated before destructive clearing: a supplied position (`>= 0`) wins, otherwise retained pre-clear progress is used, otherwise playback starts at zero.
- Existing upstream move/replace unit tests pass, and the new list-management methods are unchanged by this patch.
