### PR TITLE
fix(android): preserve playback state when seeking

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
@@ -415,12 +415,7 @@ public class PlaylistPlugin : Plugin(), OnStatusReportListener {
             val seekPosition =
                 (call.getFloat("position", position / 1000.0f)!! * 1000.0f).toLong()
 
-            val isPlaying: Boolean? =
-                audioPlayerImpl!!.playlistManager.playlistHandler?.currentMediaPlayer?.isPlaying
             audioPlayerImpl!!.playlistManager.playlistHandler?.seek(seekPosition)
-            if (isPlaying === null || !isPlaying) {
-                audioPlayerImpl!!.playlistManager.playlistHandler?.pause(false)
-            }
 
             call.resolve()
 

--- a/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
@@ -67,6 +67,13 @@ public class AudioPlaylistHandler<I extends PlaylistItem, M extends BasePlaylist
         startItemPlayback(0, !this.isPlaying());
     }
 
+    @Override
+    public void seek(long positionMillis) {
+        if (getCurrentMediaPlayer() != null) {
+            super.seek(positionMillis);
+        }
+    }
+
     /**
      * Request audio focus before starting ExoMedia — DefaultPlaylistHandler.play() starts the
      * MediaPlayer first, which fails silently after native video handoff (focus abandoned in


### PR DESCRIPTION
## Summary

- let PlaylistCore restore the playback state captured when a seek begins
- ignore seek requests until a native media player exists
- remove the plugin bridge's competing post-seek pause transition

## Why

PlaylistCore already records whether playback was active in `performSeek()` and restores that state in `onSeekComplete()`. The plugin currently adds a second state decision around the same seek and can race the handler's callback. It also allows `seek()` with no loaded media player: PlaylistCore then reports `SEEKING`, but no player exists to produce the completion callback that clears it.

## Validation

Replayed the reviewed one-commit patch onto current upstream `main` at `25ebb26` (v0.11.2).

- `git range-diff` reports the replayed patch unchanged.
- GitHub compare reports one commit, zero commits behind, and only the two intended Android files.
- Inspected the actual PlaylistCore 2.2.0 dependency bytecode: `performSeek()` captures `isPlaying()`, `onSeekComplete()` restores play/pause, and a null media player can still be followed by a `SEEKING` state update.
- `mise x node@24 java@openjdk-21 -- npm run verify:android` completed all 158 Gradle tasks: debug/release compilation, unit tests, lint, checks, and AAR assembly.
- Applied this PR and the pause-intent PR in both orders; both orders were conflict-free and produced the identical tree. The combined tree passed the upstream 60-task Android test suite.
- Rawy's Android native smoke exercises a seek while paused and verifies playback remains paused until an explicit resume; the latest emulator run completed that transition and advanced from the requested two-second position afterward.
