### PR TITLE
fix(android): preserve pause intent while loading

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/PlaylistPlugin.kt
@@ -371,9 +371,7 @@ public class PlaylistPlugin : Plugin(), OnStatusReportListener {
     @PluginMethod
     fun pause(call: PluginCall) {
         Handler(Looper.getMainLooper()).post {
-            if (audioPlayerImpl!!.playlistManager.isPlaying) {
-                audioPlayerImpl!!.playlistManager.playlistHandler?.pause(false)
-            }
+            audioPlayerImpl!!.playlistManager.playlistHandler?.pause(false)
 
             call.resolve()
 

--- a/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
@@ -79,6 +79,10 @@ public class AudioPlaylistHandler<I extends PlaylistItem, M extends BasePlaylist
             setupForeground();
             return;
         }
+        if (getCurrentPlaybackState() == PlaybackState.SEEKING) {
+            setPlayingBeforeSeek(true);
+        }
+        setStartPaused(false);
         getAudioFocusProvider().requestFocus();
         com.devbrackets.android.playlistcore.api.MediaPlayerApi<I> mediaPlayer = getCurrentMediaPlayer();
         if (mediaPlayer != null) {
@@ -102,8 +106,6 @@ public class AudioPlaylistHandler<I extends PlaylistItem, M extends BasePlaylist
      */
     public void resumePlaybackAfterVideoHandoff(long positionMs) {
         ((PlaylistManager) getPlaylistManager()).setVideoHandoffForegroundRetain(false);
-        setStartPaused(false);
-        getAudioFocusProvider().requestFocus();
         play();
         if (positionMs > 0) {
             seek(positionMs);
@@ -127,6 +129,11 @@ public class AudioPlaylistHandler<I extends PlaylistItem, M extends BasePlaylist
 
     @Override
     public void pause(boolean isTemporary) {
+        if (!isTemporary) {
+            setStartPaused(true);
+            setPausedForSeek(false);
+            setPlayingBeforeSeek(false);
+        }
         if (((PlaylistManager) getPlaylistManager()).getVideoHandoffForegroundRetain()) {
             if (isPlaying()) {
                 com.devbrackets.android.playlistcore.api.MediaPlayerApi<I> mediaPlayer = getCurrentMediaPlayer();


### PR DESCRIPTION
## Summary

- route permanent pause requests through the handler even during loading or seeking
- make explicit play/pause update the pending preparation and seek intent
- keep temporary seek/focus pauses resumable and centralize focus acquisition in `play()`

## Why

The bridge currently drops `pause()` whenever the manager is not yet reporting `isPlaying`. A pause issued while a track is preparing or seeking therefore does not update the pending intent, and a later callback can start playback against the user's request. Conversely, play during a seek can be overwritten by the stale pre-seek state.

## Validation

Replayed the reviewed one-commit patch onto current upstream `main` at `25ebb26` (v0.11.2), including the current native-video handoff code.

- `git range-diff` reports the replayed patch unchanged.
- GitHub compare reports one commit, zero commits behind, and only the two intended Android files.
- Inspected the actual PlaylistCore 2.2.0 dependency bytecode and its `startPaused`, `pausedForSeek`, and `playingBeforeSeek` transitions; permanent pause clears resumable seek state, while explicit play restores the pending play intent.
- `mise x node@24 java@openjdk-21 -- npm run verify:android` completed all 158 Gradle tasks: debug/release compilation, unit tests, lint, checks, and AAR assembly.
- Applied this PR and the seek-state PR in both orders; both orders were conflict-free and produced the identical tree. The combined tree passed the upstream 60-task Android test suite.
- Rawy's Android native smoke pauses immediately after requesting a track transition and verifies the new track stays paused before an explicit resume; the latest emulator run reported `paused_during_transition: true` and completed the subsequent seek/resume path.
